### PR TITLE
Fix spreadsheetByTitle()

### DIFF
--- a/src/GoogleSheets/Sheets.php
+++ b/src/GoogleSheets/Sheets.php
@@ -56,7 +56,7 @@ class Sheets
     public function spreadsheetByTitle($title)
     {
         $list = $this->spreadsheetList();
-        $id = array_get($list, $title);
+        $id = array_get(array_flip($list), $title);
 
         $this->spreadsheetId = $id;
 


### PR DESCRIPTION
Flip the $list before using `array_get()`.
$list was `id => title` but it should be `title => id` to work with `array_get()`