### PR TITLE
Fix when trying to retrieve an empty Sheet

### DIFF
--- a/src/GoogleSheets/Traits/SheetsValues.php
+++ b/src/GoogleSheets/Traits/SheetsValues.php
@@ -35,7 +35,7 @@ trait SheetsValues
 
         $values = $sheets->getValueRanges()[0]->getValues();
 
-        return $values;
+        return $values : $values : [];
     }
 
     /**

--- a/src/GoogleSheets/Traits/SheetsValues.php
+++ b/src/GoogleSheets/Traits/SheetsValues.php
@@ -35,7 +35,7 @@ trait SheetsValues
 
         $values = $sheets->getValueRanges()[0]->getValues();
 
-        return $values : $values : [];
+        return $values ? $values : [];
     }
 
     /**


### PR DESCRIPTION
Returning an empty array would suffice the requirement for typecasting the return as "array".