### PR TITLE
Change `null` values to empty strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ $rows = Sheets::sheet('Sheet 1')->get();
 $header = $rows->pull(0);
 $values = Sheets::collection($header, $rows);
 $values->toArray()
-[
-  ['id' => '1', 'name' => 'name1', 'mail' => 'mail1'],
-  ['id' => '2', 'name' => 'name2', 'mail' => 'mail2']
-]
-
+// [
+//   ['id' => '1', 'name' => 'name1', 'mail' => 'mail1'],
+//   ['id' => '2', 'name' => 'name2', 'mail' => 'mail2']
+// ]
 ```
-view
+
+Blade
 ```php
 @foreach($values as $value)
   {{ data_get($value, 'name') }}
@@ -144,12 +144,12 @@ $values = Sheets::sheet('Sheet 1')->range('A1:B2')->all();
 ```php
 Sheets::sheet('Sheet 1')->range('A4')->update([['3', 'name3', 'mail3']]);
 $values = Sheets::range('')->all();
-[
-  ['id', 'name', 'mail'],
-  ['1', 'name1', 'mail1'],
-  ['2', 'name1', 'mail2'],
-  ['3', 'name3', 'mail3']
-]
+// [
+//   ['id', 'name', 'mail'],
+//   ['1', 'name1', 'mail1'],
+//   ['2', 'name1', 'mail2'],
+//   ['3', 'name3', 'mail3']
+// ]
 ```
 
 ### Append a set of values to a sheet
@@ -157,12 +157,12 @@ $values = Sheets::range('')->all();
 // When we don't provide a specific range, the sheet becomes the default range
 Sheets::sheet('Sheet 1')->append([['3', 'name3', 'mail3']]);
 $values = Sheets::all();
-[
-  ['id', 'name', 'mail'],
-  ['1', 'name1', 'mail1'],
-  ['2', 'name1', 'mail2'],
-  ['3', 'name3', 'mail3']
-]
+// [
+//   ['id', 'name', 'mail'],
+//   ['1', 'name1', 'mail1'],
+//   ['2', 'name1', 'mail2'],
+//   ['3', 'name3', 'mail3']
+// ]
 ```
 
 ### Append a set of values with keys
@@ -170,13 +170,13 @@ $values = Sheets::all();
 // When providing an associative array, values get matched up to the headers in the provided sheet
 Sheets::sheet('Sheet 1')->append([['name' => 'name4', 'mail' => 'mail4', 'id' => 4]]);
 $values = Sheets::all();
-[
-  ['id', 'name', 'mail'],
-  ['1', 'name1', 'mail1'],
-  ['2', 'name1', 'mail2'],
-  ['3', 'name3', 'mail3'],
-  ['4', 'name4', 'mail4'],
-]
+// [
+//   ['id', 'name', 'mail'],
+//   ['1', 'name1', 'mail1'],
+//   ['2', 'name1', 'mail2'],
+//   ['3', 'name3', 'mail3'],
+//   ['4', 'name4', 'mail4'],
+// ]
 ```
 
 ### Add a new sheet

--- a/src/Concerns/SheetsValues.php
+++ b/src/Concerns/SheetsValues.php
@@ -144,6 +144,7 @@ trait SheetsValues
                     array_push($notNull, $value);
                 }
             }
+
             return $notNull;
         }, $ordered);
     }

--- a/src/Concerns/SheetsValues.php
+++ b/src/Concerns/SheetsValues.php
@@ -119,17 +119,33 @@ trait SheetsValues
         if (! $this->isAssociatedArray($values[0])) {
             return $values;
         }
+
         // The array has keys, which we want to map to headers and order
         $header = $this->first();
 
         $ordered = [];
-
         // Gets just the values of an array that has been re-ordered to match the header order
         foreach ($values as $value) {
-            array_push($ordered, array_values(array_replace(array_flip($header), $value)));
+            array_push(
+                $ordered,
+                array_values(array_replace(array_flip($header), $value))
+            );
         }
 
-        return $ordered;
+        // Replaces null values with empty strings to work with Google's API
+        return array_map(function ($row) {
+            $notNull = [];
+            foreach ($row as $key => $value) {
+                // If key is the same as value, that's because the user
+                // didn't specify a header that exists in the sheet.
+                if (is_null($value) || $key === $value) {
+                    array_push($notNull, '');
+                } else {
+                    array_push($notNull, $value);
+                }
+            }
+            return $notNull;
+        }, $ordered);
     }
 
     /**

--- a/tests/SheetsMockTest.php
+++ b/tests/SheetsMockTest.php
@@ -172,7 +172,7 @@ class SheetsMockTest extends TestCase
             ->andReturn($response);
 
         $ordered = $this->sheet->orderAppendables([['header2' => 'value3', 'header1' => null]]);
-        $this->assertSame([[null, 'value3']], $ordered);
+        $this->assertSame([['', 'value3']], $ordered);
     }
 
     public function testSpreadsheetProperties()


### PR DESCRIPTION
Google's API doesn't accept `null` when appending, so I updated the method to change `null` values to an empty string when passing through key-value pairs.