### PR TITLE
Laravel 9 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "illuminate/container": "^6.0||^7.0||^8.0||^9.0",
     "illuminate/support": "^6.0||^7.0||^8.0||^9.0",
     "google/apiclient": "^2.10",
-    "pulkitjalan/google-apiclient": "^4.1||^5.0"
+    "pulkitjalan/google-apiclient": "^4.1||^5.0||^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
Adds pulkitjalan/google-apiclient 6.0 compatibility, which adds Laravel 9.x compatibility.