### PR TITLE
Move implementation of Google Sheet client into this project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.lock
 .DS_Store
 tests/data/test*
 !tests/data/test-config-sample.php
+.idea
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ composer require revolution/laravel-google-sheets
 
 ### Laravel
 
-1. This package depends on https://github.com/pulkitjalan/google-apiclient
-
-2. Run `php artisan vendor:publish --provider="PulkitJalan\Google\GoogleServiceProvider" --tag="config"` to publish the google config file
+1. Run `php artisan vendor:publish --provider="Revolution\Google\Sheets\GoogleSheetClient" --tag="config"` to publish the google config file
 
         // config/google.php
 
@@ -41,10 +39,10 @@ composer require revolution/laravel-google-sheets
         'file'    => storage_path('credentials.json'),
         'enable'  => env('GOOGLE_SERVICE_ENABLED', true),
 
-3. Get API Credentials from https://developers.google.com/console  
+2. Get API Credentials from https://developers.google.com/console  
 Enable `Google Sheets API`, `Google Drive API`.
 
-4. Configure .env as needed
+3. Configure .env as needed
 
         GOOGLE_APPLICATION_NAME=
         GOOGLE_CLIENT_ID=

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "google/apiclient": "^2.12"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^9.5|^10.0",
     "mockery/mockery": "^1.0",
     "orchestra/testbench": "^7.0||^8.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   ],
   "license": "MIT",
   "require": {
-    "php": "^8.0",
+    "php": ">=8.0",
     "illuminate/container": "^9.0||^10.0",
     "illuminate/support": "^9.0||^10.0",
     "google/apiclient": "^2.12"

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     "php": "^8.0",
     "illuminate/container": "^9.0||^10.0",
     "illuminate/support": "^9.0||^10.0",
-    "google/apiclient": "^2.12",
-    "pulkitjalan/google-apiclient": "^6.0"
+    "google/apiclient": "^2.12"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
@@ -38,7 +37,8 @@
   "extra": {
     "laravel": {
       "providers": [
-        "Revolution\\Google\\Sheets\\Providers\\SheetsServiceProvider"
+        "Revolution\\Google\\Sheets\\Providers\\SheetsServiceProvider",
+        "Revolution\\Google\\Sheets\\Providers\\GoogleServiceProvider"
       ],
       "aliases": {
         "Sheets": "Revolution\\Google\\Sheets\\Facades\\Sheets"

--- a/config/google.php
+++ b/config/google.php
@@ -1,0 +1,73 @@
+<?php
+
+return [
+    /*
+    |----------------------------------------------------------------------------
+    | Google application name
+    |----------------------------------------------------------------------------
+    */
+    'application_name' => env('GOOGLE_APPLICATION_NAME', ''),
+
+    /*
+    |----------------------------------------------------------------------------
+    | Google OAuth 2.0 access
+    |----------------------------------------------------------------------------
+    |
+    | Keys for OAuth 2.0 access, see the API console at
+    | https://developers.google.com/console
+    |
+    */
+    'client_id' => env('GOOGLE_CLIENT_ID', ''),
+    'client_secret' => env('GOOGLE_CLIENT_SECRET', ''),
+    'redirect_uri' => env('GOOGLE_REDIRECT', ''),
+    'scopes' => [],
+    'access_type' => 'online',
+    'approval_prompt' => 'auto',
+
+    /*
+    |----------------------------------------------------------------------------
+    | Google developer key
+    |----------------------------------------------------------------------------
+    |
+    | Simple API access key, also from the API console. Ensure you get
+    | a Server key, and not a Browser key.
+    |
+    */
+    'developer_key' => env('GOOGLE_DEVELOPER_KEY', ''),
+
+    /*
+    |----------------------------------------------------------------------------
+    | Google service account
+    |----------------------------------------------------------------------------
+    |
+    | Set the credentials JSON's location to use assert credentials, otherwise
+    | app engine or compute engine will be used.
+    |
+    */
+    'service' => [
+        /*
+        | Enable service account auth or not.
+        */
+        'enable' => env('GOOGLE_SERVICE_ENABLED', false),
+
+        /*
+         * Path to service account json file. You can also pass the credentials as an array
+         * instead of a file path.
+         */
+        'file' => env('GOOGLE_SERVICE_ACCOUNT_JSON_LOCATION', ''),
+    ],
+
+    /*
+    |----------------------------------------------------------------------------
+    | Additional config for the Google Client
+    |----------------------------------------------------------------------------
+    |
+    | Set any additional config variables supported by the Google Client
+    | Details can be found here:
+    | https://github.com/google/google-api-php-client/blob/master/src/Google/Client.php
+    |
+    | NOTE: If client id is specified here, it will get over written by the one above.
+    |
+    */
+    'config' => [],
+];

--- a/src/Concerns/SheetsDrive.php
+++ b/src/Concerns/SheetsDrive.php
@@ -5,7 +5,7 @@ namespace Revolution\Google\Sheets\Concerns;
 use Google\Service;
 use Google\Service\Drive;
 use Illuminate\Container\Container;
-use PulkitJalan\Google\Client;
+use Revolution\Google\Sheets\GoogleSheetClient;
 
 trait SheetsDrive
 {
@@ -54,7 +54,7 @@ trait SheetsDrive
     public function getDriveService(): Service|Drive
     {
         if (is_null($this->drive)) {
-            $this->drive = Container::getInstance()->make(Client::class)->make('drive');
+            $this->drive = Container::getInstance()->make(GoogleSheetClient::class)->make('drive');
         }
 
         return $this->drive;

--- a/src/Exceptions/UnknownServiceException.php
+++ b/src/Exceptions/UnknownServiceException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Revolution\Google\Sheets\Exceptions;
+
+class UnknownServiceException extends \Exception
+{
+}

--- a/src/Facades/Google.php
+++ b/src/Facades/Google.php
@@ -2,8 +2,8 @@
 
 namespace Revolution\Google\Sheets\Facades;
 
-use Revolution\Google\Sheets\GoogleSheetClient;
 use Illuminate\Support\Facades\Facade;
+use Revolution\Google\Sheets\GoogleSheetClient;
 
 /**
  * @mixin GoogleSheetClient

--- a/src/Facades/Google.php
+++ b/src/Facades/Google.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Revolution\Google\Sheets\Facades;
+
+use Revolution\Google\Sheets\GoogleSheetClient;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @mixin GoogleSheetClient
+ */
+class Google extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return GoogleSheetClient::class;
+    }
+}

--- a/src/GoogleSheetClient.php
+++ b/src/GoogleSheetClient.php
@@ -2,8 +2,8 @@
 
 namespace Revolution\Google\Sheets;
 
-use Illuminate\Support\Arr;
 use Google\Client as GoogleClient;
+use Illuminate\Support\Arr;
 use Revolution\Google\Sheets\Exceptions\UnknownServiceException;
 
 class GoogleSheetClient

--- a/src/GoogleSheetClient.php
+++ b/src/GoogleSheetClient.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Revolution\Google\Sheets;
+
+use Illuminate\Support\Arr;
+use Google\Client as GoogleClient;
+use Revolution\Google\Sheets\Exceptions\UnknownServiceException;
+
+class GoogleSheetClient
+{
+    /**
+     * @var array
+     */
+    protected $config;
+
+    /**
+     * @var GoogleSheetClient
+     */
+    protected $client;
+
+    /**
+     * @param  array  $config
+     * @param  string  $userEmail
+     */
+    public function __construct(array $config, $userEmail = '')
+    {
+        $this->config = $config;
+
+        // create an instance of the google client for OAuth2
+        $this->client = new GoogleClient(Arr::get($config, 'config', []));
+
+        // set application name
+        $this->client->setApplicationName(Arr::get($config, 'application_name', ''));
+
+        // set oauth2 configs
+        $this->client->setClientId(Arr::get($config, 'client_id', ''));
+        $this->client->setClientSecret(Arr::get($config, 'client_secret', ''));
+        $this->client->setRedirectUri(Arr::get($config, 'redirect_uri', ''));
+        $this->client->setScopes(Arr::get($config, 'scopes', []));
+        $this->client->setAccessType(Arr::get($config, 'access_type', 'online'));
+        $this->client->setApprovalPrompt(Arr::get($config, 'approval_prompt', 'auto'));
+
+        // set developer key
+        $this->client->setDeveloperKey(Arr::get($config, 'developer_key', ''));
+
+        // auth for service account
+        if (Arr::get($config, 'service.enable', false)) {
+            $this->auth($userEmail);
+        }
+    }
+
+    /**
+     * Getter for the google client.
+     *
+     * @return GoogleSheetClient
+     */
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    /**
+     * Setter for the google client.
+     *
+     * @param  string  $client
+     * @return self
+     */
+    public function setClient(GoogleClient $client)
+    {
+        $this->client = $client;
+
+        return $this;
+    }
+
+    /**
+     * Getter for the google service.
+     *
+     * @param  string  $service
+     * @return \Google_Service
+     *
+     * @throws \Exception
+     */
+    public function make($service)
+    {
+        $service = 'Google\\Service\\'.ucfirst($service);
+
+        if (class_exists($service)) {
+            $class = new \ReflectionClass($service);
+
+            return $class->newInstance($this->client);
+        }
+
+        throw new UnknownServiceException($service);
+    }
+
+    /**
+     * Setup correct auth method based on type.
+     *
+     * @param $userEmail
+     * @return void
+     */
+    protected function auth($userEmail = '')
+    {
+        // see (and use) if user has set Credentials
+        if ($this->useAssertCredentials($userEmail)) {
+            return;
+        }
+
+        // fallback to compute engine or app engine
+        $this->client->useApplicationDefaultCredentials();
+    }
+
+    /**
+     * Determine and use credentials if user has set them.
+     *
+     * @param $userEmail
+     * @return bool used or not
+     */
+    protected function useAssertCredentials($userEmail = '')
+    {
+        $serviceJsonUrl = Arr::get($this->config, 'service.file', '');
+
+        if (empty($serviceJsonUrl)) {
+            return false;
+        }
+
+        $this->client->setAuthConfig($serviceJsonUrl);
+
+        if (! empty($userEmail)) {
+            $this->client->setSubject($userEmail);
+        }
+
+        return true;
+    }
+
+    /**
+     * Magic call method.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        if (method_exists($this->client, $method)) {
+            return call_user_func_array([$this->client, $method], $parameters);
+        }
+
+        throw new \BadMethodCallException(sprintf('Method [%s] does not exist.', $method));
+    }
+}

--- a/src/Providers/GoogleServiceProvider.php
+++ b/src/Providers/GoogleServiceProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Revolution\Google\Sheets\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Revolution\Google\Sheets\GoogleSheetClient;
+
+class GoogleServiceProvider extends ServiceProvider
+{
+    /**
+     * Boot the service provider.
+     */
+    public function boot()
+    {
+        if (function_exists('config_path')) {
+            $this->publishes([
+                __DIR__.'/../../config/google.php' => config_path('google.php'),
+            ], 'config');
+        }
+    }
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->mergeConfigFrom(__DIR__.'/../../config/google.php', 'google');
+
+        $this->app->bind('Revolution\Google\Sheets\GoogleSheetClient', function ($app) {
+            return new GoogleSheetClient($app['config']['google']);
+        });
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return string[]
+     */
+    public function provides()
+    {
+        return ['Revolution\Google\Sheets\GoogleSheetClient'];
+    }
+}

--- a/src/Sheets.php
+++ b/src/Sheets.php
@@ -10,7 +10,6 @@ use Illuminate\Container\Container;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
-use PulkitJalan\Google\Client;
 use Revolution\Google\Sheets\Contracts\Factory;
 
 class Sheets implements Factory
@@ -56,7 +55,7 @@ class Sheets implements Factory
     public function getService(): GoogleSheets
     {
         if (is_null($this->service)) {
-            $this->service = Container::getInstance()->make(Client::class)->make('sheets');
+            $this->service = Container::getInstance()->make(GoogleSheetClient::class)->make('sheets');
         }
 
         return $this->service;
@@ -73,9 +72,9 @@ class Sheets implements Factory
     public function setAccessToken(array|string $token): static
     {
         /**
-         * @var Client $google
+         * @var GoogleSheetClient $google
          */
-        $google = Container::getInstance()->make(Client::class);
+        $google = Container::getInstance()->make(GoogleSheetClient::class);
 
         $google->getCache()->clear();
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Revolution\Google\Sheets\Tests;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Revolution\Google\Sheets\Exceptions\UnknownServiceException;
+use Revolution\Google\Sheets\GoogleSheetClient;
+
+class ClientTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function testClientGetter()
+    {
+        $client = Mockery::mock(GoogleSheetClient::class, [[]])->makePartial();
+
+        $this->assertInstanceOf('Google\Client', $client->getClient());
+    }
+
+    public function testClientGetterWithAdditionalConfig()
+    {
+        $client = Mockery::mock(GoogleSheetClient::class, [[
+            'config' => [
+                'subject' => 'test',
+            ],
+        ]])->makePartial();
+
+        $this->assertEquals($client->getClient()->getConfig('subject'), 'test');
+    }
+
+    public function testServiceMake()
+    {
+        $client = Mockery::mock(GoogleSheetClient::class, [[]])->makePartial();
+
+        $this->assertInstanceOf('Google\Service\Storage', $client->make('storage'));
+    }
+
+    public function testServiceMakeException()
+    {
+        $client = Mockery::mock(GoogleSheetClient::class, [[]])->makePartial();
+
+        $this->expectException(UnknownServiceException::class);
+
+        $client->make('storag');
+    }
+
+    public function testMagicMethodException()
+    {
+        $client = new GoogleSheetClient([]);
+
+        $this->expectException('BadMethodCallException');
+
+        $client->getAuthTest();
+    }
+
+    public function testNoCredentials()
+    {
+        $client = new GoogleSheetClient([]);
+
+        $this->assertFalse($client->isUsingApplicationDefaultCredentials());
+    }
+
+    public function testDefaultCredentials()
+    {
+        $client = new GoogleSheetClient([
+            'service' => [
+                'enable' => true,
+                'file' => __DIR__.'/data/test.json',
+            ],
+        ]);
+
+        $this->assertTrue($client->isUsingApplicationDefaultCredentials());
+    }
+}

--- a/tests/SheetsDriveTest.php
+++ b/tests/SheetsDriveTest.php
@@ -6,8 +6,8 @@ use Google\Service\Drive;
 use Google\Service\Drive\DriveFile;
 use Google\Service\Drive\Resource\Files;
 use Mockery as m;
-use Revolution\Google\Sheets\GoogleSheetClient;
 use Revolution\Google\Sheets\Facades\Sheets;
+use Revolution\Google\Sheets\GoogleSheetClient;
 
 class SheetsDriveTest extends TestCase
 {

--- a/tests/SheetsDriveTest.php
+++ b/tests/SheetsDriveTest.php
@@ -6,7 +6,7 @@ use Google\Service\Drive;
 use Google\Service\Drive\DriveFile;
 use Google\Service\Drive\Resource\Files;
 use Mockery as m;
-use PulkitJalan\Google\Client;
+use Revolution\Google\Sheets\GoogleSheetClient;
 use Revolution\Google\Sheets\Facades\Sheets;
 
 class SheetsDriveTest extends TestCase
@@ -52,7 +52,7 @@ class SheetsDriveTest extends TestCase
 
     public function testNull()
     {
-        $this->mock(Client::class, function ($mock) {
+        $this->mock(GoogleSheetClient::class, function ($mock) {
             $mock->shouldReceive('make')->andReturn($this->service);
         });
 

--- a/tests/SheetsTest.php
+++ b/tests/SheetsTest.php
@@ -3,14 +3,14 @@
 namespace Revolution\Google\Sheets\Tests;
 
 use Mockery as m;
-use PulkitJalan\Google\Client;
+use Revolution\Google\Sheets\GoogleSheetClient;
 use Revolution\Google\Sheets\Facades\Sheets;
 use Revolution\Google\Sheets\Traits\GoogleSheets;
 
 class SheetsTest extends TestCase
 {
     /**
-     * @var \PulkitJalan\Google\Client
+     * @var \Revolution\Google\Sheets\Providers\Client
      */
     protected $google;
 
@@ -18,8 +18,8 @@ class SheetsTest extends TestCase
     {
         parent::setUp();
 
-        $this->google = m::mock(Client::class);
-        app()->instance(Client::class, $this->google);
+        $this->google = m::mock(GoogleSheetClient::class);
+        app()->instance(GoogleSheetClient::class, $this->google);
     }
 
     public function tearDown(): void

--- a/tests/SheetsTest.php
+++ b/tests/SheetsTest.php
@@ -3,14 +3,14 @@
 namespace Revolution\Google\Sheets\Tests;
 
 use Mockery as m;
-use Revolution\Google\Sheets\GoogleSheetClient;
 use Revolution\Google\Sheets\Facades\Sheets;
+use Revolution\Google\Sheets\GoogleSheetClient;
 use Revolution\Google\Sheets\Traits\GoogleSheets;
 
 class SheetsTest extends TestCase
 {
     /**
-     * @var \Revolution\Google\Sheets\Providers\Client
+     * @var GoogleSheetClient
      */
     protected $google;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,9 @@
 
 namespace Revolution\Google\Sheets\Tests;
 
-use Revolution\Google\Sheets\Providers\Facades\Google;
-use Revolution\Google\Sheets\Providers\GoogleServiceProvider;
 use Revolution\Google\Sheets\Facades\Sheets;
+use Revolution\Google\Sheets\Facades\Google;
+use Revolution\Google\Sheets\Providers\GoogleServiceProvider;
 use Revolution\Google\Sheets\Providers\SheetsServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,8 @@
 
 namespace Revolution\Google\Sheets\Tests;
 
-use Revolution\Google\Sheets\Facades\Sheets;
 use Revolution\Google\Sheets\Facades\Google;
+use Revolution\Google\Sheets\Facades\Sheets;
 use Revolution\Google\Sheets\Providers\GoogleServiceProvider;
 use Revolution\Google\Sheets\Providers\SheetsServiceProvider;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,8 @@
 
 namespace Revolution\Google\Sheets\Tests;
 
-use PulkitJalan\Google\Facades\Google;
-use PulkitJalan\Google\GoogleServiceProvider;
+use Revolution\Google\Sheets\Providers\Facades\Google;
+use Revolution\Google\Sheets\Providers\GoogleServiceProvider;
 use Revolution\Google\Sheets\Facades\Sheets;
 use Revolution\Google\Sheets\Providers\SheetsServiceProvider;
 


### PR DESCRIPTION
Moving Google Sheet Client implementation into this project, since it seems like the original implementation is not being maintained (https://github.com/pulkitjalan/google-apiclient)

Test results:

**PHP 8.0.27 & PHPUnit 9.6.3**
```
PHPUnit 9.6.3 by Sebastian Bergmann and contributors.

......................................                            38 / 38 (100%)

Time: 00:00.142, Memory: 28.00 MB

OK (38 tests, 46 assertions)
```

**PHP 8.1.14 & PHPUnit 9.6.3**
```
PHPUnit 9.6.3 by Sebastian Bergmann and contributors.

......................................                            38 / 38 (100%)

Time: 00:00.144, Memory: 28.00 MB

OK (38 tests, 46 assertions)
```

**PHP 8.1.14 & PHPUnit 10.0.8**
```
PHPUnit 10.0.8 by Sebastian Bergmann and contributors.

......................................                            38 / 38 (100%)

Time: 00:01.149, Memory: 32.00 MB

OK (38 tests, 46 assertions)
```

**PHP 8.2.1 & PHPUnit 10.0.8**
```
PHPUnit 10.0.8 by Sebastian Bergmann and contributors.

......................................                            38 / 38 (100%)

Time: 00:01.164, Memory: 32.00 MB

OK (38 tests, 46 assertions)
```
