### PR TITLE
bump google/apiclient version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php": "^8.1",
     "illuminate/container": "^10.0||^11.0",
     "illuminate/support": "^10.0||^11.0",
-    "google/apiclient": "^2.12"
+    "google/apiclient": "^2.15"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.0",


### PR DESCRIPTION
bump to the latest google/apiclient version.

Motivation:
versions bellow 2.15 allows [firebase/php-jwt](https://packagist.org/packages/firebase/php-jwt) bellow 6.0 (https://github.com/advisories/GHSA-8xf4-w7qw-pjjw)